### PR TITLE
Using URL to download cx_freeze

### DIFF
--- a/projects/cxfreeze.cmake
+++ b/projects/cxfreeze.cmake
@@ -1,5 +1,5 @@
 ExternalProject_Add(cx_Freeze
-    HG_REPOSITORY https://bitbucket.org/anthony_tuininga/cx_freeze
+    URL https://bitbucket.org/anthony_tuininga/cx_freeze/get/4.3.4.tar.gz
     CONFIGURE_COMMAND ""
     PATCH_COMMAND hg import --no-commit ${CMAKE_CURRENT_LIST_DIR}/cxfreeze_exclude_self.patch
     BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build

--- a/projects/cxfreeze.cmake
+++ b/projects/cxfreeze.cmake
@@ -1,5 +1,5 @@
 ExternalProject_Add(cx_Freeze
-    URL https://bitbucket.org/anthony_tuininga/cx_freeze/get/4.3.4.tar.gz
+    URL https://bitbucket.org/anthony_tuininga/cx_freeze/get/tip.tar.gz
     CONFIGURE_COMMAND ""
     PATCH_COMMAND hg import --no-commit ${CMAKE_CURRENT_LIST_DIR}/cxfreeze_exclude_self.patch
     BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build


### PR DESCRIPTION
Use url to download the lastest codebase of cx_freeze release instead of using a HG clone.

The benefit is that hg is not needed on Windows as a new dependency.
If there is a need for the latest codebase we can use also prepackaged "master" copies.
I guess these are called "tip" in hg: https://bitbucket.org/anthony_tuininga/cx_freeze/downloads?tab=tags
